### PR TITLE
Enable dynamic zone in components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,5 @@
 {
   "private": true,
-  "dependencies": {
-    "redux-saga": "1.1.3"
-  },
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.12.1",
     "@swc-node/jest": "^1.1.0",
@@ -42,6 +39,7 @@
     "prettier": "^1.18.2",
     "qs": "6.9.4",
     "react-test-renderer": "^17.0.1",
+    "redux-saga": "1.1.3",
     "request": "^2.87.0",
     "request-promise-native": "^1.0.9",
     "rimraf": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "private": true,
-  "dependencies": {},
+  "dependencies": {
+    "redux-saga": "1.1.3"
+  },
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.12.1",
     "@swc-node/jest": "^1.1.0",

--- a/packages/strapi-plugin-content-manager/admin/src/components/DynamicZone/utils/select.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/DynamicZone/utils/select.js
@@ -17,20 +17,49 @@ function useSelect(name) {
   } = useDataManager();
 
   const dynamicDisplayedComponents = useMemo(
-    () => get(modifiedData, [name], []).map(data => data.__component),
+    () => get(modifiedData, name, []).map(data => data.__component),
     [modifiedData, name]
   );
+
+  /**
+   * Will strip the numeric ID part of a Name path to help with the name matching
+   *
+   * E.g. if we have a repeatable component Comp1 with a DynamicZone ZoneA
+   * The Name for each DZ in multiple instances of the Comp1 will be Comp1.0.ZoneA, Comp1.1.ZoneA
+   * But the permissions object has the name as Comp1.ZoneA because it does not deal with actual instances
+   * of the component but the model.
+   * As result, lookup for permissions by name will not work as is. So we strip the dynamic part of the name.
+   * @param {string[]} items is an array of input names
+   * @param {string} name is a name of the input we are looking for
+   */
+  const contains = (items, name) => {
+    const parts = name.split('.');
+    const canonicalName = parts
+      .filter(part => {
+        return Number.isNaN(part) || Number.isNaN(parseFloat(part));
+      })
+      .join('.');
+    console.log(canonicalName);
+    
+return items.includes(canonicalName);
+  };
 
   const isFieldAllowed = useMemo(() => {
     const allowedFields = isCreatingEntry ? createActionAllowedFields : updateActionAllowedFields;
 
-    return allowedFields.includes(name);
+    // return allowedFields.includes(name);
+    // Repeatable components have names like CompName.NumericId.DZName
+    // Simple string match will not work. Hence we use more clever utility function here
+    return contains(allowedFields, name);
   }, [name, isCreatingEntry, createActionAllowedFields, updateActionAllowedFields]);
 
   const isFieldReadable = useMemo(() => {
     const allowedFields = isCreatingEntry ? [] : readActionAllowedFields;
 
-    return allowedFields.includes(name);
+    // return allowedFields.includes(name);
+    // Repeatable components have names like CompName.NumericId.DZName
+    // Simple string match will not work. Hence we use more clever utility function here
+    return contains(allowedFields, name);
   }, [name, isCreatingEntry, readActionAllowedFields]);
 
   return {

--- a/packages/strapi-plugin-content-manager/admin/src/components/NonRepeatableComponent/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/NonRepeatableComponent/index.js
@@ -7,6 +7,7 @@ import { useContentTypeLayout } from '../../hooks';
 import NonRepeatableWrapper from '../NonRepeatableWrapper';
 import Inputs from '../Inputs';
 import FieldComponent from '../FieldComponent';
+import DynamicZone from '../DynamicZone';
 
 const NonRepeatableComponent = ({ componentUid, isFromDynamicZone, name }) => {
   const { getComponentLayout } = useContentTypeLayout();
@@ -23,6 +24,7 @@ const NonRepeatableComponent = ({ componentUid, isFromDynamicZone, name }) => {
           <div className="row" key={key}>
             {fieldRow.map(({ name: fieldName, size, metadatas, fieldSchema, queryInfos }) => {
               const isComponent = fieldSchema.type === 'component';
+              const isDynamicZone = fieldSchema.type === 'dynamiczone';
               const keys = `${name}.${fieldName}`;
 
               if (isComponent) {
@@ -41,16 +43,25 @@ const NonRepeatableComponent = ({ componentUid, isFromDynamicZone, name }) => {
                 );
               }
 
-              return (
-                <div key={fieldName} className={`col-${size}`}>
-                  <Inputs
-                    keys={keys}
-                    fieldSchema={fieldSchema}
-                    metadatas={metadatas}
-                    componentUid={componentUid}
-                    queryInfos={queryInfos}
-                  />
-                </div>
+              // DynamicZone is now available inside the Component
+              if (isDynamicZone) {
+                return (
+                  <div key={fieldName} className={`col-${size}`}>
+                    <DynamicZone name={keys} fieldSchema={fieldSchema} metadatas={metadatas} />
+                  </div>
+                );
+              }
+              
+return (
+  <div key={fieldName} className={`col-${size}`}>
+    <Inputs
+      keys={keys}
+      fieldSchema={fieldSchema}
+      metadatas={metadatas}
+      componentUid={componentUid}
+      queryInfos={queryInfos}
+    />
+  </div>
               );
             })}
           </div>

--- a/packages/strapi-plugin-content-manager/admin/src/components/NonRepeatableComponent/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/NonRepeatableComponent/index.js
@@ -51,17 +51,17 @@ const NonRepeatableComponent = ({ componentUid, isFromDynamicZone, name }) => {
                   </div>
                 );
               }
-              
-return (
-  <div key={fieldName} className={`col-${size}`}>
-    <Inputs
-      keys={keys}
-      fieldSchema={fieldSchema}
-      metadatas={metadatas}
-      componentUid={componentUid}
-      queryInfos={queryInfos}
-    />
-  </div>
+
+              return (
+                <div key={fieldName} className={`col-${size}`}>
+                  <Inputs
+                    keys={keys}
+                    fieldSchema={fieldSchema}
+                    metadatas={metadatas}
+                    componentUid={componentUid}
+                    queryInfos={queryInfos}
+                  />
+                </div>
               );
             })}
           </div>

--- a/packages/strapi-plugin-content-manager/admin/src/components/RepeatableComponent/DraggedItem/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/RepeatableComponent/DraggedItem/index.js
@@ -10,6 +10,7 @@ import FieldComponent from '../../FieldComponent';
 import Banner from '../Banner';
 import FormWrapper from '../FormWrapper';
 import { connect, select } from './utils';
+import DynamicZone from '../../DynamicZone';
 
 /* eslint-disable react/no-array-index-key */
 
@@ -169,6 +170,7 @@ const DraggedItem = ({
                   <div className="row" key={key}>
                     {fieldRow.map(({ name, fieldSchema, metadatas, queryInfos, size }) => {
                       const isComponent = fieldSchema.type === 'component';
+                      const isDynamicZone = fieldSchema.type === 'dynamiczone';
                       const keys = `${componentFieldName}.${name}`;
 
                       if (isComponent) {
@@ -185,6 +187,18 @@ const DraggedItem = ({
                             max={fieldSchema.max}
                             min={fieldSchema.min}
                           />
+                        );
+                      }
+
+                      if (isDynamicZone) {
+                        return (
+                          <div key={name} className={`col-${size}`}>
+                            <DynamicZone
+                              name={keys}
+                              fieldSchema={fieldSchema}
+                              metadatas={metadatas}
+                            />
+                          </div>
                         );
                       }
 

--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditViewDataManagerProvider/reducer.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditViewDataManagerProvider/reducer.js
@@ -53,7 +53,7 @@ const reducer = (state, action) => {
 
           return fromJS([defaultDataStructure]);
         })
-        .update('modifiedDZName', () => action.keys[0])
+        .update('modifiedDZName', () => action.keys.join('.')) // When DZ is in component the name is like a json-path
         .update('shouldCheckErrors', v => {
           if (action.shouldCheckErrors === true) {
             return !v;
@@ -92,8 +92,11 @@ const reducer = (state, action) => {
             state.getIn(['modifiedData', ...action.pathToComponent, action.dragIndex])
           );
       });
-    case 'MOVE_COMPONENT_UP':
-      return state
+    case 'MOVE_COMPONENT_UP': {
+      // The name is a path, hence should be treated as an array
+      const path = action.dynamicZoneName.split('.');
+      
+return state
         .update('shouldCheckErrors', v => {
           if (action.shouldCheckErrors) {
             return !v;
@@ -101,16 +104,20 @@ const reducer = (state, action) => {
 
           return v;
         })
-        .updateIn(['modifiedData', action.dynamicZoneName], list => {
+        .updateIn(['modifiedData', ...path], list => {
           return list
             .delete(action.currentIndex)
             .insert(
               action.currentIndex - 1,
-              state.getIn(['modifiedData', action.dynamicZoneName, action.currentIndex])
+              state.getIn(['modifiedData', ...path, action.currentIndex])
             );
         });
-    case 'MOVE_COMPONENT_DOWN':
-      return state
+    }
+    case 'MOVE_COMPONENT_DOWN': {
+      // The name is a path, hence should be treated as an array
+      const path = action.dynamicZoneName.split('.');
+      
+return state
         .update('shouldCheckErrors', v => {
           if (action.shouldCheckErrors) {
             return !v;
@@ -118,14 +125,15 @@ const reducer = (state, action) => {
 
           return v;
         })
-        .updateIn(['modifiedData', action.dynamicZoneName], list => {
+        .updateIn(['modifiedData', ...path], list => {
           return list
             .delete(action.currentIndex)
             .insert(
               action.currentIndex + 1,
-              state.getIn(['modifiedData', action.dynamicZoneName, action.currentIndex])
+              state.getIn(['modifiedData', ...path, action.currentIndex])
             );
         });
+    }
     case 'MOVE_FIELD':
       return state.updateIn(['modifiedData', ...action.keys], list => {
         return list.delete(action.dragIndex).insert(action.overIndex, list.get(action.dragIndex));
@@ -155,8 +163,11 @@ const reducer = (state, action) => {
         return action.value;
       });
     }
-    case 'REMOVE_COMPONENT_FROM_DYNAMIC_ZONE':
-      return state
+    case 'REMOVE_COMPONENT_FROM_DYNAMIC_ZONE': {
+      // The name is a path, hence should be treated as an array
+      const path = action.dynamicZoneName.split('.');
+      
+return state
         .update('shouldCheckErrors', v => {
           if (action.shouldCheckErrors) {
             return !v;
@@ -164,7 +175,8 @@ const reducer = (state, action) => {
 
           return v;
         })
-        .deleteIn(['modifiedData', action.dynamicZoneName, action.index]);
+        .deleteIn(['modifiedData', ...path, action.index]);
+    }
     case 'REMOVE_COMPONENT_FROM_FIELD': {
       const componentPathToRemove = ['modifiedData', ...action.keys];
 

--- a/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/attributes.js
+++ b/packages/strapi-plugin-content-type-builder/admin/src/containers/FormModal/utils/attributes.js
@@ -27,7 +27,7 @@ const getAttributes = (dataTarget = '', targetUid, nestedComponents) => {
   }
 
   if (canAddComponentInAnotherComponent) {
-    items.push(['component']);
+    items.push(['component', 'dynamiczone']);
   }
 
   return items;


### PR DESCRIPTION
### What does it do?

This change enables Dynamic Zone rendering and functioning inside a Component.
Without this change the DynamicZone added manually into the json model file will not render or function in the Admin UI.
See [here](https://github.com/strapi/strapi/issues/5798):  and [here](https://github.com/strapi/strapi/issues/6283) for details.

**NOTE: This is dirty and most likely not production-ready solution but it allows me to have the functionality I need while the official upstream repo is lacking it. According to official comments from the Strapi team, it is unlikely they will have any alternative any time soon.**

### Why is it needed?

#### The case for using components over relations

The upstream Strapi implementation restricts use of DynamicZone to the content types only.
However, for the good content creation experience the current version of the entry editor lacks the ability to create child/related entries of other types from within the parent one.
For example, if we have a type Course that has a relation to a type lesson. Ideal flow for a course creator would be to create a Course and while filling in the course details to be able to create and add new lessons without needing to go to the lessons collection first and creating all the lessons first. It should be all in one place experience.
At the moment, you can only choose existing related entries but not create a new one.

If in the future it changes and user will be able to invoke an editor for a related type(entry) dynamically (like adding a component) this would be preferred approach.

Alternative to this would be to use Components. Although, one should keep in mind that they have limitations (such as no filtering can be done on Components).

#### The case for using DynamicZone inside a Component

Let's say the course wants to organise lessons into chapters. Following the Components approach we would have a Chapter component that includes multiple lessons.
Now the course would have repeatable Chapter component so that the course creator can dynamically create as many chapters as they like while creating a course record.
As we want to dynamically create + add lessons, they should be Components too.
This is acceptable until the point when you have more than one type of lessons and a course creator wants to pick which type of a lesson to add to a course dynamically.
Dynamic choice of an element in Strapi is done via DynamicZone. Therefore, we need a Component to support Dynamic Zone too.

### How to test it?

One will have to manually modify a type model definition file (json) to include a dynamic zone there first.
e.g.

```
{
  "collectionName": "components_default_my_test_components",
  "info": {
    "name": "MyTestComponent",
    "icon": "adjust"
  },
  "options": {},
  "attributes": {
    "title": {
      "type": "string"
    },
    "mydz": {
      "type": "dynamiczone",
      "components": ["default.lesson", "default.questionary"]
    }
  }
}
```
Then go to Admin UI and create a type that uses the `MyTestComponent`.
When creating new entries of the new content type, observe that the dynamic zone is correctly rendered and functions.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/5798
https://github.com/strapi/strapi/issues/6283