### PR TITLE
Create property at path if doesn't exist on plugin

### DIFF
--- a/packages/strapi/lib/core/load-modules.js
+++ b/packages/strapi/lib/core/load-modules.js
@@ -46,7 +46,14 @@ module.exports = async strapi => {
 
   // overwrite plugins with extensions overwrites
   extensions.overwrites.forEach(({ path, mod }) => {
-    _.assign(_.get(plugins, path), mod);
+    const pluginValue = _.get(plugins, path);
+    // If the overwite is not found on original plugin, add the property
+    // This covers the use case when a new model for a plugin is added.
+    if (pluginValue) {
+      _.assign(pluginValue, mod);
+    } else {
+      _.set(plugins, path, mod);
+    }
   });
 
   return {


### PR DESCRIPTION
What does it do?
When loading overwrites for plugins, if a model found in the overwrites (./extensions/ folder) does not exist on a plugins object, we add the value of that model at the path specified in the overwrites.

Why is it needed?
Use case:
When extending a users-permissions plugin need to create a new model. Adding new model to the extensions folder does not work without this change. The only option is to fork the Strapi and make changes directly in the source of the users-permissions plugin.

With this change, the models will be added to the plugin upon strapi startup.

How to test it?
Extend users-permissions plugin and add a new model in the extension. The model should be available later to use in code.

Related issue(s)/PR(s)
Nothing really except my question in the forum that is not answered so far: https://forum.strapi.io/t/add-new-model-to-strapi-plugin-users-permissions/9242